### PR TITLE
fix(jira): correct search endpoint in JiraIssues.searchIssues to /res…

### DIFF
--- a/.windsurf_plan.md
+++ b/.windsurf_plan.md
@@ -8,8 +8,12 @@
     - List with options, add/update with visibility/properties/flags, delete, get single, get by IDs
   - Extended MCP `jiraIssueToolkit` to support new actions and options
   - Added `listCommentsFull` toolkit action to return raw comments + extracted plain text in a single call
+  - Fix `JiraIssues.searchIssues` endpoint: change `/rest/api/3/search/jql` to `/rest/api/3/search`; keep `jql` as query parameter
+- **[status]** Implemented fix in `src/tools/jira/client/issues.ts`.
 - **[next]**
   - Consider adding `getCommentWithThread` (parent/children) aggregation if needed
   - Address pre-existing `Env` lint (`COOKIE_ENCRYPTION_KEY`) in `src/index.ts`
+  - Monitor for search regressions; add tests for `fieldsByKeys`, pagination (`startAt`, `maxResults`).
 - **[notes]**
   - Keep interfaces aligned with Jira OpenAPI as we add more endpoints.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,8 @@
 
 ### Notes
 - A pre-existing lint warning remains regarding `Env` in `src/index.ts` (missing `COOKIE_ENCRYPTION_KEY`). This was not introduced by this change. Consider updating the `Env` type or configuration accordingly.
+
+- fix(jira): Correct search endpoint in `JiraIssues.searchIssues` (`src/tools/jira/client/issues.ts`).
+  - Changed from `/rest/api/3/search/jql` to `/rest/api/3/search`.
+  - Rationale: Jira REST API expects `jql` as a query parameter, not a path segment. This resolves MCP search errors.
+

--- a/src/tools/jira/client/issues.ts
+++ b/src/tools/jira/client/issues.ts
@@ -111,7 +111,7 @@ export class JiraIssues extends JiraClientCore {
     if (properties) params.set("properties", properties);
     if (options.fieldsByKeys !== undefined) params.set("fieldsByKeys", String(options.fieldsByKeys));
 
-    return this.makeRequest<JiraIssueSearchResult>(`/rest/api/3/search/jql?${params.toString()}`);
+    return this.makeRequest<JiraIssueSearchResult>(`/rest/api/3/search?${params.toString()}`);
   }
 
   public async getTransitions(issueIdOrKey: string): Promise<JiraTransitionsResponse> {


### PR DESCRIPTION
…t/api/3/search; jql stays as query param

- Fix MCP error caused by incorrect path
- Update .windsurf_plan.md and CHANGELOG.md